### PR TITLE
Document envvars for testacc

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 *Note:* Acceptance tests create real resources, and often cost money to run.
 
 Acceptance tests need an authentication token and an Online.net server which will be used to run the tests against.
-The server will be modified, using a production system is not adviced.
+The server will be modified, using a production system is not adviced. All used servers must support RPNv2.
 It will look for:
 
-| Environment Variable | Description                                                                  | Example | 
-|----------------------|------------------------------------------------------------------------------|---------|
-| `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part)                             | `46952` |
-| `ONLINE_TOKEN`       | Online.net auth token received from https://console.online.net/en/api/access |         |
-
+| Environment Variable | Description                                                                  | Example     | 
+|----------------------|------------------------------------------------------------------------------|-------------|
+| `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part)                             | `46952`     |
+| `ONLINE_SERVER_ID_2` | ID of a 2nd dedicated server (only the numeric part)                         | `46953`     |
+| `ONILE_FAILVOVER_IP` | An available failover IP                                                     | `81.23.14.1`|
+| `ONLINE_TOKEN`       | Online.net auth token received from https://console.online.net/en/api/access |             |
 
 ```sh
 $ make testacc

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ It will look for:
 
 | Environment Variable | Description                                                                  | Example | 
 |----------------------|------------------------------------------------------------------------------|---------|
-| `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part)                             |`46952`  |
+| `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part)                             | `46952` |
 | `ONLINE_TOKEN`       | Online.net auth token received from https://console.online.net/en/api/access |         |
 
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It will look for:
 |----------------------|------------------------------------------------------------------------------|-------------|
 | `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part)                             | `46952`     |
 | `ONLINE_SERVER_ID_2` | ID of a 2nd dedicated server (only the numeric part)                         | `46953`     |
-| `ONILE_FAILVOVER_IP` | An available failover IP                                                     | `81.23.14.1`|
+| `ONLINE_FAILVOVER_IP` | An available failover IP                                                     | `81.23.14.1`|
 | `ONLINE_TOKEN`       | Online.net auth token received from https://console.online.net/en/api/access |             |
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -86,9 +86,17 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 
 *Note:* Acceptance tests create real resources, and often cost money to run.
 
+Acceptance tests need an authentication token and an Online.net server which will be used to run the tests against.
+The server will be modified, using a production system is not adviced.
+It will look for:
+
+| Environment Variable | Description              |
+|----------------------|--------------------------|
+| `ONLINE_SERVER_ID`   | ID of a dedicated server |
+| `ONLINE_TOKEN`       | Online.net auth token    |
+
+
 ```sh
-$ export ONLINE_SERVER_ID=(ID of a dedicated server to run tests against)
-$ export ONLINE_TOKEN=(Online.net auth token)
 $ make testacc
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ It will look for:
 
 | Environment Variable | Description              |
 |----------------------|--------------------------|
-| `ONLINE_SERVER_ID`   | ID of a dedicated server |
-| `ONLINE_TOKEN`       | Online.net auth token    |
+| `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part) |
+| `ONLINE_TOKEN`       | Online.net auth token received from https://console.online.net/en/api/access   |
 
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 *Note:* Acceptance tests create real resources, and often cost money to run.
 
 ```sh
+$ export ONLINE_SERVER_ID=(ID of a dedicated server to run tests against)
+$ export ONLINE_TOKEN=(Online.net auth token)
 $ make testacc
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Acceptance tests need an authentication token and an Online.net server which wil
 The server will be modified, using a production system is not adviced.
 It will look for:
 
-| Environment Variable | Description              |
-|----------------------|--------------------------|
-| `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part) |
-| `ONLINE_TOKEN`       | Online.net auth token received from https://console.online.net/en/api/access   |
+| Environment Variable | Description                                                                  | Example | 
+|----------------------|------------------------------------------------------------------------------|---------|
+| `ONLINE_SERVER_ID`   | ID of a dedicated server (only the numeric part)                             |`46952`  |
+| `ONLINE_TOKEN`       | Online.net auth token received from https://console.online.net/en/api/access |         |
 
 
 ```sh


### PR DESCRIPTION
Document the envvars that are needed in the acceptance tests

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>